### PR TITLE
Expose the script as global `FreelookCamera` class

### DIFF
--- a/camera.gd
+++ b/camera.gd
@@ -1,4 +1,4 @@
-extends Camera
+class_name FreelookCamera extends Camera
 
 export(float, 0.0, 1.0) var sensitivity = 0.25
 


### PR DESCRIPTION
Allows to create a freelook camera node via create dialog more easily.